### PR TITLE
add shibboleth.yml deployment

### DIFF
--- a/roles/leihs-legacy-install/defaults/main.yml
+++ b/roles/leihs-legacy-install/defaults/main.yml
@@ -4,3 +4,4 @@ leihs_legacy_clean_slate: false
 leihs_legacy_user: leihs-legacy
 leihs_legacy_max_threads_per_worker: 2
 leihs_leagcy_workers: '{{ansible_processor_vcpus}}'
+shibboleth_file_path: '{{inventory_dir}}/settings/shibboleth.yml'

--- a/roles/leihs-legacy-install/tasks/settings.yml
+++ b/roles/leihs-legacy-install/tasks/settings.yml
@@ -4,3 +4,11 @@
     owner: '{{leihs_legacy_user}}'
   name: copy settings.yml file to leihs_legacy
   tags: [settings]
+
+- copy:
+    src: '{{shibboleth_file_path}}'
+    dest: '{{leihs_legacy_path}}/config/shibboleth.yml'
+    owner: '{{leihs_legacy_user}}'
+  failed_when: false
+  name: copy shibboleth.yml file to leihs_legacy
+  tags: [settings]


### PR DESCRIPTION
With this change the shibboleth.yml configuration is copied to leihs_legacy config folder on ansible deployment. If shibboleth.yml is not available in the settings folder, no error will be raised, so it doesn't break things for other users.